### PR TITLE
Report Windows OS names, not version numbers.

### DIFF
--- a/Bugsense.WPF/CrashInformationCollector.cs
+++ b/Bugsense.WPF/CrashInformationCollector.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using System.Text;
 
 namespace Bugsense.WPF
@@ -18,7 +17,7 @@ namespace Bugsense.WPF
         public BugSenseRequest CreateCrashReport(Exception exception)
         {
             var entryAssemblyName = _assemblyRepository.GetEntryAssembly().GetName();
-            var operatingSystem = Environment.OSVersion;
+            var operatingSystem = GetOSName(Environment.OSVersion);
 
             var fullStacktrace = GetStackTrace(exception);
 
@@ -34,9 +33,36 @@ namespace Bugsense.WPF
                     {
                         AppName = entryAssemblyName.Name,
                         AppVersion = _version ?? entryAssemblyName.Version.ToString(4),
-                        OsVersion = operatingSystem.Version.ToString(4)
+                        OsVersion = operatingSystem
                     }
                 );
+        }
+
+        private static string GetOSName(OperatingSystem os)
+        {
+            Version version = os.Version;
+
+            // perform simple detection of OS
+            // TODO: more sophisticated detection; Windows 7 and Server 2008 have the same major/minor version number 
+            string release;
+            if (version.Major == 5 && version.Minor == 1)
+                release = "XP";
+            else if (version.Major == 5 && version.Minor == 2)
+                release = "Server 2003";
+            else if (version.Major == 6 && version.Minor == 0)
+                release = "Vista";
+            else if (version.Major == 6 && version.Minor == 1)
+                release = "7";
+            else if (version.Major == 6 && version.Minor == 2)
+                release = "8";
+            else if (version.Major == 6 && version.Minor == 3)
+                release = "8.1";
+            else
+                release = version.ToString();
+
+            string servicePack = string.IsNullOrEmpty(os.ServicePack) ? "" : (" " + os.ServicePack.Replace("Service Pack ", "SP"));
+
+            return "Windows " + release + servicePack;
         }
 
         private static string GetStackTrace(Exception exception)

--- a/Bugsense.WPF/CrashInformationCollector.cs
+++ b/Bugsense.WPF/CrashInformationCollector.cs
@@ -62,7 +62,7 @@ namespace Bugsense.WPF
 
             string servicePack = string.IsNullOrEmpty(os.ServicePack) ? "" : (" " + os.ServicePack.Replace("Service Pack ", "SP"));
 
-            return "Windows " + release + servicePack;
+            return release + servicePack;
         }
 
         private static string GetStackTrace(Exception exception)


### PR DESCRIPTION
Fixes [issue #2](https://github.com/vidstige/Bugsense.WPF/issues/2).

All current Windows client OS versions will be reported using the product name they were sold under (e.g., "Windows Vista SP2", "Windows 7") instead of the OS version number (e.g., `6.1.7600.0`).

This code doesn't differentiate between client and server SKUs (e.g., Windows 8 vs Windows Server 2012) as that information is not in the OperatingSystem class, but only available by checking whether `OSVERSIONINFOEX.wProductType == VER_NT_WORKSTATION` (in `GetVersionEx`).
